### PR TITLE
Auto reconnect + minor edits

### DIFF
--- a/Client/MainForm.Designer.cs
+++ b/Client/MainForm.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.ipBox = new System.Windows.Forms.TextBox();
-            this.button1 = new System.Windows.Forms.Button();
+            this.connectButton = new System.Windows.Forms.Button();
             this.clientBox = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.linkLabel1 = new System.Windows.Forms.LinkLabel();
@@ -44,7 +44,7 @@
             this.bigKeyBox = new System.Windows.Forms.TextBox();
             this.label5 = new System.Windows.Forms.Label();
             this.bigTextBox = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
+            this.statusLabel = new System.Windows.Forms.Label();
             this.trayIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.trayContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.trayExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -57,17 +57,17 @@
             this.ipBox.Location = new System.Drawing.Point(107, 61);
             this.ipBox.Name = "ipBox";
             this.ipBox.Size = new System.Drawing.Size(100, 20);
-            this.ipBox.TabIndex = 0;
+            this.ipBox.TabIndex = 1;
             // 
-            // button1
+            // connectButton
             // 
-            this.button1.Location = new System.Drawing.Point(120, 358);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
-            this.button1.TabIndex = 1;
-            this.button1.Text = "Connect";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.Button1_Click);
+            this.connectButton.Location = new System.Drawing.Point(120, 358);
+            this.connectButton.Name = "connectButton";
+            this.connectButton.Size = new System.Drawing.Size(75, 23);
+            this.connectButton.TabIndex = 13;
+            this.connectButton.Text = "Connect";
+            this.connectButton.UseVisualStyleBackColor = true;
+            this.connectButton.Click += new System.EventHandler(this.Button1_Click);
             // 
             // clientBox
             // 
@@ -75,7 +75,7 @@
             this.clientBox.MaxLength = 18;
             this.clientBox.Name = "clientBox";
             this.clientBox.Size = new System.Drawing.Size(100, 20);
-            this.clientBox.TabIndex = 2;
+            this.clientBox.TabIndex = 3;
             // 
             // label1
             // 
@@ -83,7 +83,7 @@
             this.label1.Location = new System.Drawing.Point(149, 45);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(17, 13);
-            this.label1.TabIndex = 3;
+            this.label1.TabIndex = 0;
             this.label1.Text = "IP";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
@@ -93,7 +93,7 @@
             this.linkLabel1.Location = new System.Drawing.Point(134, 91);
             this.linkLabel1.Name = "linkLabel1";
             this.linkLabel1.Size = new System.Drawing.Size(47, 13);
-            this.linkLabel1.TabIndex = 4;
+            this.linkLabel1.TabIndex = 16;
             this.linkLabel1.TabStop = true;
             this.linkLabel1.Text = "Client ID";
             this.linkLabel1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -108,7 +108,7 @@
             this.checkTime.Location = new System.Drawing.Point(100, 393);
             this.checkTime.Name = "checkTime";
             this.checkTime.Size = new System.Drawing.Size(117, 17);
-            this.checkTime.TabIndex = 5;
+            this.checkTime.TabIndex = 14;
             this.checkTime.Text = "Show Time Lapsed";
             this.checkTime.UseVisualStyleBackColor = true;
             this.checkTime.CheckedChanged += new System.EventHandler(this.CheckTime_CheckedChanged);
@@ -119,7 +119,7 @@
             this.label2.Location = new System.Drawing.Point(129, 275);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(56, 13);
-            this.label2.TabIndex = 7;
+            this.label2.TabIndex = 10;
             this.label2.Text = "State Text";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
@@ -129,7 +129,7 @@
             this.stateBox.MaxLength = 128;
             this.stateBox.Name = "stateBox";
             this.stateBox.Size = new System.Drawing.Size(100, 20);
-            this.stateBox.TabIndex = 6;
+            this.stateBox.TabIndex = 11;
             this.stateBox.TextChanged += new System.EventHandler(this.StateBox_TextChanged);
             // 
             // label3
@@ -138,7 +138,7 @@
             this.label3.Location = new System.Drawing.Point(115, 226);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(85, 13);
-            this.label3.TabIndex = 9;
+            this.label3.TabIndex = 8;
             this.label3.Text = "Small Image Key";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
@@ -148,7 +148,7 @@
             this.smallKeyBox.MaxLength = 32;
             this.smallKeyBox.Name = "smallKeyBox";
             this.smallKeyBox.Size = new System.Drawing.Size(100, 20);
-            this.smallKeyBox.TabIndex = 8;
+            this.smallKeyBox.TabIndex = 9;
             this.smallKeyBox.TextChanged += new System.EventHandler(this.SKeyBox_TextChanged);
             // 
             // label4
@@ -157,7 +157,7 @@
             this.label4.Location = new System.Drawing.Point(114, 142);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(87, 13);
-            this.label4.TabIndex = 11;
+            this.label4.TabIndex = 4;
             this.label4.Text = "Large Image Key";
             // 
             // bigKeyBox
@@ -166,7 +166,7 @@
             this.bigKeyBox.MaxLength = 32;
             this.bigKeyBox.Name = "bigKeyBox";
             this.bigKeyBox.Size = new System.Drawing.Size(100, 20);
-            this.bigKeyBox.TabIndex = 10;
+            this.bigKeyBox.TabIndex = 5;
             this.bigKeyBox.TextChanged += new System.EventHandler(this.BigKeyBox_TextChanged);
             // 
             // label5
@@ -175,7 +175,7 @@
             this.label5.Location = new System.Drawing.Point(112, 183);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(90, 13);
-            this.label5.TabIndex = 13;
+            this.label5.TabIndex = 6;
             this.label5.Text = "Large Image Text";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
@@ -185,20 +185,18 @@
             this.bigTextBox.MaxLength = 128;
             this.bigTextBox.Name = "bigTextBox";
             this.bigTextBox.Size = new System.Drawing.Size(100, 20);
-            this.bigTextBox.TabIndex = 12;
+            this.bigTextBox.TabIndex = 7;
             this.bigTextBox.TextChanged += new System.EventHandler(this.BigTextBox_TextChanged);
             // 
-            // label6
+            // statusLabel
             // 
-            this.label6.AutoSize = true;
-            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.ForeColor = System.Drawing.Color.Red;
-            this.label6.Location = new System.Drawing.Point(54, 323);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(203, 26);
-            this.label6.TabIndex = 14;
-            this.label6.Text = "If you go to sleep while connected\r\n you will have to reconnect!";
-            this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.statusLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.statusLabel.ForeColor = System.Drawing.Color.Red;
+            this.statusLabel.Location = new System.Drawing.Point(12, 314);
+            this.statusLabel.Name = "statusLabel";
+            this.statusLabel.Size = new System.Drawing.Size(290, 41);
+            this.statusLabel.TabIndex = 12;
+            this.statusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // trayIcon
             // 
@@ -213,12 +211,12 @@
             this.trayContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.trayExitMenuItem});
             this.trayContextMenu.Name = "trayContextMenu";
-            this.trayContextMenu.Size = new System.Drawing.Size(94, 26);
+            this.trayContextMenu.Size = new System.Drawing.Size(93, 26);
             // 
             // trayExitMenuItem
             // 
             this.trayExitMenuItem.Name = "trayExitMenuItem";
-            this.trayExitMenuItem.Size = new System.Drawing.Size(93, 22);
+            this.trayExitMenuItem.Size = new System.Drawing.Size(92, 22);
             this.trayExitMenuItem.Text = "Exit";
             this.trayExitMenuItem.Click += new System.EventHandler(this.TrayExitMenuItem_Click);
             // 
@@ -238,7 +236,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(314, 455);
             this.Controls.Add(this.checkTray);
-            this.Controls.Add(this.label6);
+            this.Controls.Add(this.statusLabel);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.bigTextBox);
             this.Controls.Add(this.label4);
@@ -251,7 +249,7 @@
             this.Controls.Add(this.linkLabel1);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.clientBox);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.connectButton);
             this.Controls.Add(this.ipBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -270,7 +268,7 @@
         #endregion
 
         private System.Windows.Forms.TextBox ipBox;
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button connectButton;
         private System.Windows.Forms.TextBox clientBox;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.LinkLabel linkLabel1;
@@ -283,7 +281,7 @@
         private System.Windows.Forms.TextBox bigKeyBox;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.TextBox bigTextBox;
-        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label statusLabel;
         private System.Windows.Forms.NotifyIcon trayIcon;
         private System.Windows.Forms.ContextMenuStrip trayContextMenu;
         private System.Windows.Forms.ToolStripMenuItem trayExitMenuItem;

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -45,11 +45,13 @@ namespace SwitchPresence_Rewritten
                 if (!IPAddress.TryParse(ipBox.Text, out IPAddress ip))
                 {
                     UpdateStatus("Invalid IP", Color.DarkRed);
+                    System.Media.SystemSounds.Exclamation.Play();
                     return;
                 }
                 if (string.IsNullOrWhiteSpace(clientBox.Text))
                 {
                     UpdateStatus("Client ID cannot be empty", Color.DarkRed);
+                    System.Media.SystemSounds.Exclamation.Play();
                     return;
                 }
 
@@ -88,11 +90,11 @@ namespace SwitchPresence_Rewritten
 
                 client = new Socket(SocketType.Stream, ProtocolType.Tcp)
                 {
-                    ReceiveTimeout = 10000
+                    ReceiveTimeout = 5500
                 };
                 IAsyncResult result = client.BeginConnect(localEndPoint, null, null);
 
-                UpdateStatus("Connecting to server...", Color.Gray);
+                UpdateStatus("Attemping to connect to server...", Color.Gray);
                 bool success = result.AsyncWaitHandle.WaitOne(2000, true);
                 if (!success)
                 {

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -163,36 +163,32 @@ namespace SwitchPresence_Rewritten
                         }
                         if ((rpc != null && rpc.CurrentPresence == null) || LastGame != title.name || ManualUpdate)
                         {
+                            Assets ass = new Assets
+                            {
+                                SmallImageKey = smallKeyBox.Text,
+                                SmallImageText = "Switch-Presence Rewritten"
+                            };
+                            RichPresence presence = new RichPresence
+                            {
+                                State = stateBox.Text
+                            };
+
                             if (title.name == "NULL")
                             {
-                                /*
                                 ass.LargeImageText = "Home Menu";
                                 ass.LargeImageText = !string.IsNullOrWhiteSpace(bigTextBox.Text) ? bigTextBox.Text : "Home Menu";
                                 ass.LargeImageKey = !string.IsNullOrWhiteSpace(bigKeyBox.Text) ? bigKeyBox.Text : string.Format("0{0:x}", 0x0100000000001000);
                                 presence.Details = "In the home menu";
-                                */
-                                rpc.SetPresence(null);
-
                             }
                             else
                             {
-                                Assets ass = new Assets
-                                {
-                                    SmallImageKey = smallKeyBox.Text,
-                                    SmallImageText = "Switch-Presence Rewritten"
-                                };
-                                RichPresence presence = new RichPresence
-                                {
-                                    State = stateBox.Text
-                                };
-
                                 ass.LargeImageText = !string.IsNullOrWhiteSpace(bigTextBox.Text) ? bigTextBox.Text : title.name;
                                 ass.LargeImageKey = !string.IsNullOrWhiteSpace(bigKeyBox.Text) ? bigKeyBox.Text : string.Format("0{0:x}", title.tid);
                                 presence.Details = $"Playing {title.name}";
-                                presence.Assets = ass;
-                                if (checkTime.Checked) presence.Timestamps = time;
-                                rpc.SetPresence(presence);
                             }
+                            presence.Assets = ass;
+                            if (checkTime.Checked) presence.Timestamps = time;
+                            rpc.SetPresence(presence);
                             ManualUpdate = false;
                             LastGame = title.name;
                         }

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -55,9 +55,9 @@ namespace SwitchPresence_Rewritten
                     return;
                 }
 
-                
+
                 listenThread.Start();
-                
+
                 connectButton.Text = "Disconnect";
                 ipBox.Enabled = false;
                 clientBox.Enabled = false;
@@ -69,7 +69,7 @@ namespace SwitchPresence_Rewritten
                     rpc.SetPresence(null);
                     rpc.Dispose();
                 }
-                
+
                 if (client != null) client.Close();
                 listenThread.Abort();
                 listenThread = new Thread(TryConnect);
@@ -108,7 +108,7 @@ namespace SwitchPresence_Rewritten
                     {
                         StartListening();
                     }
-                    catch(SocketException)
+                    catch (SocketException)
                     {
                         client.Close();
                         if (rpc != null && !rpc.IsDisposed) rpc.Dispose();
@@ -121,17 +121,17 @@ namespace SwitchPresence_Rewritten
         {
             rpc = new DiscordRpcClient(clientBox.Text);
 #if DEBUG
-                rpc.Logger = new ConsoleLogger() { Level = LogLevel.Warning };
-                //Subscribe to events
-                rpc.OnReady += (s, obj) =>
-                {
-                    Console.WriteLine("Received Ready from user {0}", obj.User.Username);
-                };
+            rpc.Logger = new ConsoleLogger() { Level = LogLevel.Warning };
+            //Subscribe to events
+            rpc.OnReady += (s, obj) =>
+            {
+                Console.WriteLine("Received Ready from user {0}", obj.User.Username);
+            };
 
-                rpc.OnPresenceUpdate += (s, obj) =>
-                {
-                    Console.WriteLine("Received Update! {0}", obj.Presence);
-                };
+            rpc.OnPresenceUpdate += (s, obj) =>
+            {
+                Console.WriteLine("Received Update! {0}", obj.Presence);
+            };
 #endif
             rpc.Initialize();
             DataListen();

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -102,7 +102,6 @@ namespace SwitchPresence_Rewritten
                 else
                 {
                     client.EndConnect(result);
-                    UpdateStatus("Connected to the server!", Color.Green);
                     try
                     {
                         StartListening();
@@ -157,6 +156,7 @@ namespace SwitchPresence_Rewritten
                 {
                     byte[] bytes = new byte[800];
                     int cnt = client.Receive(bytes);
+                    UpdateStatus("Connected to the server!", Color.Green);
                     TitlePacket title = Utils.ByteArrayToStructure<TitlePacket>(bytes);
                     if (title.magic == 0xffaadd23)
                     {

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -11,6 +11,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
+using System.Drawing;
 
 namespace SwitchPresence_Rewritten
 {
@@ -43,12 +44,12 @@ namespace SwitchPresence_Rewritten
             {
                 if (!IPAddress.TryParse(ipBox.Text, out IPAddress ip))
                 {
-                    UpdateStatus("Invalid IP", System.Drawing.Color.DarkRed);
+                    UpdateStatus("Invalid IP", Color.DarkRed);
                     return;
                 }
                 if (string.IsNullOrWhiteSpace(clientBox.Text))
                 {
-                    UpdateStatus("Client ID cannot be empty", System.Drawing.Color.DarkRed);
+                    UpdateStatus("Client ID cannot be empty", Color.DarkRed);
                     return;
                 }
 
@@ -71,7 +72,7 @@ namespace SwitchPresence_Rewritten
                 listenThread.Abort();
                 listenThread = new Thread(TryConnect);
 
-                UpdateStatus("", System.Drawing.Color.Gray);
+                UpdateStatus("", Color.Gray);
                 connectButton.Text = "Connect";
                 ipBox.Enabled = true;
                 clientBox.Enabled = true;
@@ -84,22 +85,24 @@ namespace SwitchPresence_Rewritten
             IPEndPoint localEndPoint = new IPEndPoint(ip, 0xCAFE);
             while (true)
             {
-                
-                client = new Socket(SocketType.Stream, ProtocolType.Tcp);
-                client.ReceiveTimeout = 10000;
+
+                client = new Socket(SocketType.Stream, ProtocolType.Tcp)
+                {
+                    ReceiveTimeout = 10000
+                };
                 IAsyncResult result = client.BeginConnect(localEndPoint, null, null);
 
-                UpdateStatus("Connecting to server...", System.Drawing.Color.Gray);
+                UpdateStatus("Connecting to server...", Color.Gray);
                 bool success = result.AsyncWaitHandle.WaitOne(2000, true);
                 if (!success)
                 {
-                    //UpdateStatus("Could not connect to Server! Retrying...", System.Drawing.Color.DarkRed);
+                    //UpdateStatus("Could not connect to Server! Retrying...", Color.DarkRed);
                     client.Close();
                 }
                 else
                 {
                     client.EndConnect(result);
-                    UpdateStatus("Connected to the server!", System.Drawing.Color.Green);
+                    UpdateStatus("Connected to the server!", Color.Green);
                     try
                     {
                         StartListening();
@@ -133,7 +136,7 @@ namespace SwitchPresence_Rewritten
             DataListen();
         }
 
-        private void UpdateStatus(string text, System.Drawing.Color color)
+        private void UpdateStatus(string text, Color color)
         {
             MethodInvoker inv = () =>
             {

--- a/Server/source/main.cpp
+++ b/Server/source/main.cpp
@@ -99,6 +99,9 @@ extern "C"
 
 int main(int argc, char **argv)
 {
+	// Band-aid solution to prevent unnecessary connections during sleep mode
+	svcSleepThread(5e+9);
+
     int sock = setupSocketServer();
     struct sockaddr_in client_addr;
     socklen_t client_len = sizeof(client_addr);
@@ -108,8 +111,6 @@ int main(int argc, char **argv)
     int src;
     while (true)
     {
-        svcSleepThread(5e+9);
-
         Result rc;
         u64 pid;
         u64 tid;
@@ -131,5 +132,7 @@ int main(int argc, char **argv)
             sock = setupSocketServer();
             connection = accept(sock, (struct sockaddr *)&client_addr, &client_len);
         }
+		
+		svcSleepThread(5e+9);
     }
 }

--- a/Server/source/main.cpp
+++ b/Server/source/main.cpp
@@ -99,9 +99,6 @@ extern "C"
 
 int main(int argc, char **argv)
 {
-	// Band-aid solution to prevent unnecessary connections during sleep mode
-	svcSleepThread(5e+9);
-
     int sock = setupSocketServer();
     struct sockaddr_in client_addr;
     socklen_t client_len = sizeof(client_addr);


### PR DESCRIPTION
Thank you for your hard work on the rewrite! I couldn't for the life of me figure out how to prevent Random's project from crashing at every disconnect, so this makes my work one hundred times easier.

I implemented an auto-reconnect feature if the client doesn't receive a response after 10 seconds. This means you no longer have to manually disconnect and reconnect your switch every time it goes to sleep.

The other edits are minor and appeal to my personal preference, so feel free to edit them out:
- Changed the TabIndex order of window elements to make it easier to Tab and Shift+Tab between textboxes.
- Replaced all of the MessageBox popups with status messages to avoid interrupting the process and workflow
- Discord RPC now only shows your game status if you're playing a game, invisible otherwise
- Renamed button1, label6, and t to connectButton, statusLabel, and listenThread respectively for easier readability