### PR TITLE
Reconnect buffer + MAC address support + fixes

### DIFF
--- a/Client/Config.cs
+++ b/Client/Config.cs
@@ -1,0 +1,13 @@
+﻿#if DEBUG
+#endif
+
+namespace SwitchPresence_Rewritten
+{
+    public class Config
+    {
+        public string IP, Client, BigKey, BigText, SmallKey, State;
+        public bool DisplayTimer, AllowTray;
+
+        public Config() { }
+    }
+}

--- a/Client/GlobalSuppressions.cs
+++ b/Client/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Code Quality", "IDE0069:Disposable fields should be disposed", Justification = "<Pending>", Scope = "member", Target = "~F:SwitchPresence_Rewritten.MainForm.timer")]
+

--- a/Client/MainForm.Designer.cs
+++ b/Client/MainForm.Designer.cs
@@ -30,7 +30,7 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-            this.ipBox = new System.Windows.Forms.TextBox();
+            this.addressBox = new System.Windows.Forms.TextBox();
             this.connectButton = new System.Windows.Forms.Button();
             this.clientBox = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
@@ -47,18 +47,19 @@
             this.statusLabel = new System.Windows.Forms.Label();
             this.trayIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.trayContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.connectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.trayExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.checkTray = new System.Windows.Forms.CheckBox();
-            this.connectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.macButton = new System.Windows.Forms.Button();
             this.trayContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
             // ipBox
             // 
-            this.ipBox.Location = new System.Drawing.Point(107, 61);
-            this.ipBox.Name = "ipBox";
-            this.ipBox.Size = new System.Drawing.Size(100, 20);
-            this.ipBox.TabIndex = 1;
+            this.addressBox.Location = new System.Drawing.Point(107, 61);
+            this.addressBox.Name = "ipBox";
+            this.addressBox.Size = new System.Drawing.Size(100, 20);
+            this.addressBox.TabIndex = 1;
             // 
             // connectButton
             // 
@@ -72,7 +73,7 @@
             // 
             // clientBox
             // 
-            this.clientBox.Location = new System.Drawing.Point(107, 114);
+            this.clientBox.Location = new System.Drawing.Point(107, 108);
             this.clientBox.MaxLength = 18;
             this.clientBox.Name = "clientBox";
             this.clientBox.Size = new System.Drawing.Size(100, 20);
@@ -81,19 +82,21 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(149, 45);
+            this.label1.Location = new System.Drawing.Point(107, 45);
+            this.label1.MinimumSize = new System.Drawing.Size(100, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(17, 13);
+            this.label1.Size = new System.Drawing.Size(100, 13);
             this.label1.TabIndex = 0;
-            this.label1.Text = "IP";
+            this.label1.Text = "IP or MAC Address";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // linkLabel1
             // 
             this.linkLabel1.AutoSize = true;
-            this.linkLabel1.Location = new System.Drawing.Point(134, 91);
+            this.linkLabel1.Location = new System.Drawing.Point(107, 92);
+            this.linkLabel1.MinimumSize = new System.Drawing.Size(100, 0);
             this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(47, 13);
+            this.linkLabel1.Size = new System.Drawing.Size(100, 13);
             this.linkLabel1.TabIndex = 16;
             this.linkLabel1.TabStop = true;
             this.linkLabel1.Text = "Client ID";
@@ -117,9 +120,10 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(129, 275);
+            this.label2.Location = new System.Drawing.Point(107, 275);
+            this.label2.MinimumSize = new System.Drawing.Size(100, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(56, 13);
+            this.label2.Size = new System.Drawing.Size(100, 13);
             this.label2.TabIndex = 10;
             this.label2.Text = "State Text";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -136,9 +140,10 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(115, 226);
+            this.label3.Location = new System.Drawing.Point(107, 226);
+            this.label3.MinimumSize = new System.Drawing.Size(100, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(85, 13);
+            this.label3.Size = new System.Drawing.Size(100, 13);
             this.label3.TabIndex = 8;
             this.label3.Text = "Small Image Key";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -155,11 +160,13 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(114, 142);
+            this.label4.Location = new System.Drawing.Point(107, 142);
+            this.label4.MinimumSize = new System.Drawing.Size(100, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(87, 13);
+            this.label4.Size = new System.Drawing.Size(100, 13);
             this.label4.TabIndex = 4;
             this.label4.Text = "Large Image Key";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // bigKeyBox
             // 
@@ -173,9 +180,10 @@
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(112, 183);
+            this.label5.Location = new System.Drawing.Point(107, 186);
+            this.label5.MinimumSize = new System.Drawing.Size(100, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(90, 13);
+            this.label5.Size = new System.Drawing.Size(100, 13);
             this.label5.TabIndex = 6;
             this.label5.Text = "Large Image Text";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -213,12 +221,19 @@
             this.connectToolStripMenuItem,
             this.trayExitMenuItem});
             this.trayContextMenu.Name = "trayContextMenu";
-            this.trayContextMenu.Size = new System.Drawing.Size(181, 70);
+            this.trayContextMenu.Size = new System.Drawing.Size(120, 48);
+            // 
+            // connectToolStripMenuItem
+            // 
+            this.connectToolStripMenuItem.Name = "connectToolStripMenuItem";
+            this.connectToolStripMenuItem.Size = new System.Drawing.Size(119, 22);
+            this.connectToolStripMenuItem.Text = "Connect";
+            this.connectToolStripMenuItem.Click += new System.EventHandler(this.ConnectButton_Click);
             // 
             // trayExitMenuItem
             // 
             this.trayExitMenuItem.Name = "trayExitMenuItem";
-            this.trayExitMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.trayExitMenuItem.Size = new System.Drawing.Size(119, 22);
             this.trayExitMenuItem.Text = "Exit";
             this.trayExitMenuItem.Click += new System.EventHandler(this.TrayExitMenuItem_Click);
             // 
@@ -232,18 +247,25 @@
             this.checkTray.Text = "Minimize to Tray";
             this.checkTray.UseVisualStyleBackColor = true;
             // 
-            // connectToolStripMenuItem
+            // macButton
             // 
-            this.connectToolStripMenuItem.Name = "connectToolStripMenuItem";
-            this.connectToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.connectToolStripMenuItem.Text = "Connect";
-            this.connectToolStripMenuItem.Click += new System.EventHandler(this.ConnectButton_Click);
+            this.macButton.Enabled = false;
+            this.macButton.Location = new System.Drawing.Point(213, 60);
+            this.macButton.MinimumSize = new System.Drawing.Size(0, 22);
+            this.macButton.Name = "macButton";
+            this.macButton.Size = new System.Drawing.Size(62, 22);
+            this.macButton.TabIndex = 17;
+            this.macButton.Text = "Use MAC";
+            this.macButton.UseVisualStyleBackColor = true;
+            this.macButton.Visible = false;
+            this.macButton.Click += new System.EventHandler(this.MacButton_Click);
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(314, 455);
+            this.Controls.Add(this.macButton);
             this.Controls.Add(this.checkTray);
             this.Controls.Add(this.statusLabel);
             this.Controls.Add(this.label5);
@@ -259,7 +281,7 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.clientBox);
             this.Controls.Add(this.connectButton);
-            this.Controls.Add(this.ipBox);
+            this.Controls.Add(this.addressBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
@@ -276,7 +298,7 @@
 
         #endregion
 
-        private System.Windows.Forms.TextBox ipBox;
+        private System.Windows.Forms.TextBox addressBox;
         private System.Windows.Forms.Button connectButton;
         private System.Windows.Forms.TextBox clientBox;
         private System.Windows.Forms.Label label1;
@@ -296,6 +318,7 @@
         private System.Windows.Forms.ToolStripMenuItem trayExitMenuItem;
         private System.Windows.Forms.CheckBox checkTray;
         private System.Windows.Forms.ToolStripMenuItem connectToolStripMenuItem;
+        private System.Windows.Forms.Button macButton;
     }
 }
 

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -24,15 +24,15 @@ namespace SwitchPresence_Rewritten
 {
     public partial class MainForm : Form
     {
-        Thread listenThread;
+        private Thread listenThread;
         static Socket client;
         static DiscordRpcClient rpc;
-        IPAddress ipAddress;
-        PhysicalAddress macAddress;
+        private IPAddress ipAddress;
+        private PhysicalAddress macAddress;
         bool ManualUpdate = false;
         string LastGame = "";
-        Timestamps time = null;
-        Timer timer;
+        private Timestamps time = null;
+        private Timer timer;
         public MainForm()
         {
             InitializeComponent();

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -10,6 +10,7 @@ using System.Drawing;
 using System.IO;
 using System.Media;
 using System.Net;
+using System.Timers;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -17,6 +18,7 @@ using System.Windows.Forms;
 using System.Net.NetworkInformation;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Timer = System.Timers.Timer;
 
 namespace SwitchPresence_Rewritten
 {
@@ -112,7 +114,7 @@ namespace SwitchPresence_Rewritten
             }
         }
 
-        private void OnConnectTimeout(object source, System.Timers.ElapsedEventArgs e)
+        private void OnConnectTimeout(object source, ElapsedEventArgs e)
         {
             LastGame = "";
             time = null;
@@ -126,13 +128,13 @@ namespace SwitchPresence_Rewritten
             rpc = new DiscordRpcClient(clientBox.Text);
             rpc.Initialize();
 
-            System.Timers.Timer timer = new System.Timers.Timer()
+            Timer timer = new Timer()
             {
                 Interval = 15000,
                 SynchronizingObject = this,
                 Enabled = false,
             };
-            timer.Elapsed += new System.Timers.ElapsedEventHandler(OnConnectTimeout);
+            timer.Elapsed += new ElapsedEventHandler(OnConnectTimeout);
 
 #if DEBUG
             rpc.Logger = new ConsoleLogger() { Level = LogLevel.Warning };

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -310,7 +310,7 @@ namespace SwitchPresence_Rewritten
         public List<MacIpPair> GetAllMacAddressesAndIppairs()
         {
             List<MacIpPair> mip = new List<MacIpPair>();
-            System.Diagnostics.Process pProcess = new System.Diagnostics.Process();
+            Process pProcess = new Process();
             pProcess.StartInfo.FileName = "arp";
             pProcess.StartInfo.Arguments = "-a ";
             pProcess.StartInfo.UseShellExecute = false;
@@ -328,7 +328,7 @@ namespace SwitchPresence_Rewritten
                     IpAddress = m.Groups["ip"].Value
                 });
             }
-
+            pProcess.Dispose();
             return mip;
         }
         public struct MacIpPair

--- a/Client/MainForm.cs
+++ b/Client/MainForm.cs
@@ -32,6 +32,7 @@ namespace SwitchPresence_Rewritten
         bool ManualUpdate = false;
         string LastGame = "";
         Timestamps time = null;
+        Timer timer;
         public MainForm()
         {
             InitializeComponent();
@@ -96,6 +97,7 @@ namespace SwitchPresence_Rewritten
                 listenThread.Abort();
                 if (rpc != null && !rpc.IsDisposed) rpc.Dispose();
                 if (client != null) client.Close();
+                if (timer != null) timer.Dispose();
                 listenThread = new Thread(TryConnect);
                 UpdateStatus("", Color.Gray);
                 connectButton.Text = "Connect";
@@ -128,7 +130,7 @@ namespace SwitchPresence_Rewritten
             rpc = new DiscordRpcClient(clientBox.Text);
             rpc.Initialize();
 
-            Timer timer = new Timer()
+            timer = new Timer()
             {
                 Interval = 15000,
                 SynchronizingObject = this,

--- a/Client/SwitchPresence-Rewritten.csproj
+++ b/Client/SwitchPresence-Rewritten.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>

--- a/Client/SwitchPresence-Rewritten.csproj
+++ b/Client/SwitchPresence-Rewritten.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -95,7 +96,6 @@
     <None Include="Connected.ico" />
     <None Include="Disconnected.ico" />
     <Content Include="Icon.ico" />
-    <None Include="Resources\ConnectedIcon.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Client/Utils.cs
+++ b/Client/Utils.cs
@@ -18,7 +18,5 @@ namespace SwitchPresence_Rewritten
             }
             return stuff;
         }
-
-        //public static void WriteAllBytes(this FileInfo f, byte[] data) => File.WriteAllBytes(f.FullName, data);
     }
 }

--- a/Client/Utils.cs
+++ b/Client/Utils.cs
@@ -1,4 +1,9 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using static SwitchPresence_Rewritten.MainForm;
 
 namespace SwitchPresence_Rewritten
 {
@@ -17,6 +22,49 @@ namespace SwitchPresence_Rewritten
                 handle.Free();
             }
             return stuff;
+        }
+
+        public static string GetMacByIp(string ip)
+        {
+            List<MacIpPair> macIpPairs = GetAllMacAddressesAndIPPairs();
+            MacIpPair pair = macIpPairs.FirstOrDefault(x => x.IpAddress == ip);
+
+            return pair.MacAddress ?? "";
+        }
+
+        public static string GetIpByMac(string mac)
+        {
+            mac = mac.ToLower();
+            List<MacIpPair> macIpPairs = GetAllMacAddressesAndIPPairs();
+            MacIpPair pair = macIpPairs.FirstOrDefault(x => x.MacAddress == mac);
+
+            return pair.IpAddress ?? "";
+        }
+
+        public static List<MacIpPair> GetAllMacAddressesAndIPPairs()
+        {
+            List<MacIpPair> mip = new List<MacIpPair>();
+            using (Process pProcess = new Process())
+            {
+                pProcess.StartInfo.FileName = "arp";
+                pProcess.StartInfo.Arguments = "-a ";
+                pProcess.StartInfo.UseShellExecute = false;
+                pProcess.StartInfo.RedirectStandardOutput = true;
+                pProcess.StartInfo.CreateNoWindow = true;
+                pProcess.Start();
+                string cmdOutput = pProcess.StandardOutput.ReadToEnd();
+                string pattern = @"(?<ip>([0-9]{1,3}\.?){4})\s*(?<mac>([a-f0-9]{2}-?){6})";
+
+                foreach (Match m in Regex.Matches(cmdOutput, pattern, RegexOptions.IgnoreCase))
+                {
+                    mip.Add(new MacIpPair()
+                    {
+                        MacAddress = m.Groups["mac"].Value,
+                        IpAddress = m.Groups["ip"].Value
+                    });
+                }
+            }
+            return mip;
         }
     }
 }


### PR DESCRIPTION
Ok so this is a lot to dig in, i found plenty of various issues while testing the app since the last commit.  I'm gonna list my main revelations and steps i took to change them.

- The app would sometimes disconnect due to shoddy wifi connection and on immediate reconnection it would start the elapsed time from the beginning. Instead of resetting the time every time the client makes a connection, i made a timer in the same thread that goes off after 15 seconds to reset the elapsed time. That way, i gave the app some leeway to reconnect without losing the elapsed timer.
- Sometimes I'd notice that the app would keep showing that it's connected despite the switch being obviously offline. This has been already fixed by throwing an exception if the received bytes are 0, i approached that problem by adding a check in case the byte magic does not add up (there was none before). I believe that's a better solution long-term.
- I added the option to find the switch by IP as well as MAC address. Since IP addresses are assigned dynamically, this solves the issue of having to re-enter the switch IP every time the IP addresses are reassigned (ex. restarting the router in your local network). Additionally, i added a button that lets you convert your IP address to a MAC address so you don't have to go looking for it in your network.
- The "tray icon duplication" bug was a fluke. The main form would dispose of the tray icon regardless, so disposing of the tray icon on form closing was pointless. The real reason i get the tray duplication is due to me stopping the app via the visual studio debug menu. This stops the process entirely and there is sadly no way to check for that internally.
- I fixed the issue where the tray icon did not update when the connection was lost.