### PR TITLE
Manager: Add multiple program states other than "Enabled" and "Disabled"

### DIFF
--- a/Manager/source/states/MainMenu.cpp
+++ b/Manager/source/states/MainMenu.cpp
@@ -35,12 +35,13 @@ void MainMenu::calc(StateMachine *stateMachine, u64 inputs)
                 stateMachine->pushState("dumpRes");
                 break;
             case 1:
-                if (Utils::isPresenceActive())
+                PresenceState state = Utils::getPresenceState();
+                if (state == PresenceState::Enabled)
                 {
                     if (R_SUCCEEDED(pmshellTerminateProgram(TID)))
                         remove(BOOT2FLAG);
                 }
-                else
+                else if (state == PresenceState::Disabled)
                 {
                     u64 pid;
                     NcmProgramLocation programLocation
@@ -59,10 +60,21 @@ void MainMenu::calc(StateMachine *stateMachine, u64 inputs)
 }
 
 void MainMenu::updateStatus(){
-    if (Utils::isPresenceActive())
-        MainMenuItems[1] = "SwitchPresence is enabled!";
-    else
+    switch (Utils::getPresenceState())
+    {
+    case PresenceState::NotFound:
+        MainMenuItems[1] = CONSOLE_RED "!!! SwitchPresence could not be found!";
+        break;
+    case PresenceState::Error:
+        MainMenuItems[1] = CONSOLE_RED "!!! Failed to retreive the state of SwitchPresence!";
+        break;
+    case PresenceState::Disabled:
         MainMenuItems[1] = "SwitchPresence is disabled!";
+        break;
+    case PresenceState::Enabled:
+        MainMenuItems[1] = "SwitchPresence is enabled!";
+        break;
+    }
 }
 
 std::string MainMenu::name()

--- a/Manager/source/utils/Utils.cpp
+++ b/Manager/source/utils/Utils.cpp
@@ -23,17 +23,17 @@ void printItems(const vector<string> &items, string menuTitle, int selection)
 PresenceState getPresenceState()
 {
     PresenceState state;
-
     u64 pid = 0;
-    Result rc = pmdmntGetProcessId(&pid, TID);
 
-    if (R_SUCCEEDED(rc))
+    if (R_SUCCEEDED(pmdmntGetProcessId(&pid, TID)))
+    {
         if (pid > 0)
             //note that this returns instantly
-            // because the file might not exist but still be running
+            //because the file might not exist but still be running
             return PresenceState::Enabled;
         else
             state = PresenceState::Error;
+    }
     else
         state = PresenceState::Disabled;
 

--- a/Manager/source/utils/Utils.cpp
+++ b/Manager/source/utils/Utils.cpp
@@ -20,14 +20,27 @@ void printItems(const vector<string> &items, string menuTitle, int selection)
     }
 }
 
-bool isPresenceActive()
+PresenceState getPresenceState()
 {
+    PresenceState state;
+
     u64 pid = 0;
-    pmdmntGetProcessId(&pid, TID);
-    if (pid > 0)
-        return true;
+    Result rc = pmdmntGetProcessId(&pid, TID);
+
+    if (R_SUCCEEDED(rc))
+        if (pid > 0)
+            //note that this returns instantly
+            // because the file might not exist but still be running
+            return PresenceState::Enabled;
+        else
+            state = PresenceState::Error;
     else
-        return false;
+        state = PresenceState::Disabled;
+
+    if (!filesystem::exists(PROGRAMDIR))
+        state = PresenceState::NotFound;
+
+    return state;
 }
 
 Result DumpIcons()

--- a/Manager/source/utils/Utils.h
+++ b/Manager/source/utils/Utils.h
@@ -12,14 +12,25 @@
 #define center(p, c) ((p - c) / 2)
 
 #define TID 0x0100000000000464
-#define FLAGSDIR "sdmc:/atmosphere/contents/0100000000000464/flags/"
-#define BOOT2FLAG FLAGSDIR "boot2.flag"
+#define CONTENTSDIR "sdmc:/atmosphere/contents/0100000000000464"
+#define PROGRAMDIR CONTENTSDIR "/exefs.nsp"
+#define FLAGSDIR CONTENTSDIR "/flags"
+#define BOOT2FLAG FLAGSDIR "/boot2.flag"
+
+enum class PresenceState 
+{
+    NotFound,
+    Error,
+    Enabled,
+    Disabled,
+};
+
 namespace Utils
 {
 extern Result error_currentError;
 
 void printItems(const std::vector<std::string> &items, std::string menuTitle, int);
-bool isPresenceActive();
+PresenceState getPresenceState();
 Result DumpIcons();
 Result getAppControlData(u64, NsApplicationControlData *);
 } // namespace Utils

--- a/Manager/source/utils/Utils.h
+++ b/Manager/source/utils/Utils.h
@@ -17,7 +17,7 @@
 #define FLAGSDIR CONTENTSDIR "/flags"
 #define BOOT2FLAG FLAGSDIR "/boot2.flag"
 
-enum class PresenceState 
+enum class PresenceState
 {
     NotFound,
     Error,


### PR DESCRIPTION
Adds two more sysmodule states to be checked:
- Not found
- Error

The second one is a precaution, but the first one should notify the users that SPR is not installed on their device.