### PR TITLE
GUI Client: Add an option to display Main Menu as status

### DIFF
--- a/Client/SwitchPresence-Rewritten-GUI/Config.cs
+++ b/Client/SwitchPresence-Rewritten-GUI/Config.cs
@@ -3,6 +3,6 @@
     public class Config
     {
         public string IP, Client, BigKey, BigText, SmallKey, State;
-        public bool DisplayTimer, AllowTray;
+        public bool DisplayTimer, AllowTray, DisplayMainMenu;
     }
 }

--- a/Client/SwitchPresence-Rewritten-GUI/MainForm.Designer.cs
+++ b/Client/SwitchPresence-Rewritten-GUI/MainForm.Designer.cs
@@ -51,6 +51,7 @@
             this.trayExitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.checkTray = new System.Windows.Forms.CheckBox();
             this.macButton = new System.Windows.Forms.Button();
+            this.checkMainMenu = new System.Windows.Forms.CheckBox();
             this.trayContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -260,11 +261,25 @@
             this.macButton.Visible = false;
             this.macButton.Click += new System.EventHandler(this.MacButton_Click);
             // 
+            // checkMainMenu
+            // 
+            this.checkMainMenu.AutoSize = true;
+            this.checkMainMenu.Checked = true;
+            this.checkMainMenu.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkMainMenu.Location = new System.Drawing.Point(100, 439);
+            this.checkMainMenu.Name = "checkMainMenu";
+            this.checkMainMenu.Size = new System.Drawing.Size(170, 17);
+            this.checkMainMenu.TabIndex = 18;
+            this.checkMainMenu.Text = "Display Main Menu as a status";
+            this.checkMainMenu.UseVisualStyleBackColor = true;
+            this.checkMainMenu.CheckedChanged += new System.EventHandler(this.checkMainMenu_CheckedChanged);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(314, 455);
+            this.ClientSize = new System.Drawing.Size(314, 470);
+            this.Controls.Add(this.checkMainMenu);
             this.Controls.Add(this.macButton);
             this.Controls.Add(this.checkTray);
             this.Controls.Add(this.statusLabel);
@@ -319,6 +334,7 @@
         private System.Windows.Forms.CheckBox checkTray;
         private System.Windows.Forms.ToolStripMenuItem connectToolStripMenuItem;
         private System.Windows.Forms.Button macButton;
+        private System.Windows.Forms.CheckBox checkMainMenu;
     }
 }
 

--- a/Client/SwitchPresence-Rewritten-GUI/MainForm.Designer.cs
+++ b/Client/SwitchPresence-Rewritten-GUI/MainForm.Designer.cs
@@ -57,14 +57,14 @@
             // 
             // addressBox
             // 
-            this.addressBox.Location = new System.Drawing.Point(107, 61);
+            this.addressBox.Location = new System.Drawing.Point(107, 46);
             this.addressBox.Name = "addressBox";
             this.addressBox.Size = new System.Drawing.Size(100, 20);
             this.addressBox.TabIndex = 1;
             // 
             // connectButton
             // 
-            this.connectButton.Location = new System.Drawing.Point(120, 358);
+            this.connectButton.Location = new System.Drawing.Point(120, 343);
             this.connectButton.Name = "connectButton";
             this.connectButton.Size = new System.Drawing.Size(75, 23);
             this.connectButton.TabIndex = 13;
@@ -74,7 +74,7 @@
             // 
             // clientBox
             // 
-            this.clientBox.Location = new System.Drawing.Point(107, 108);
+            this.clientBox.Location = new System.Drawing.Point(107, 93);
             this.clientBox.MaxLength = 18;
             this.clientBox.Name = "clientBox";
             this.clientBox.Size = new System.Drawing.Size(100, 20);
@@ -83,7 +83,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(107, 45);
+            this.label1.Location = new System.Drawing.Point(107, 30);
             this.label1.MinimumSize = new System.Drawing.Size(100, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(100, 13);
@@ -94,7 +94,7 @@
             // linkLabel1
             // 
             this.linkLabel1.AutoSize = true;
-            this.linkLabel1.Location = new System.Drawing.Point(107, 92);
+            this.linkLabel1.Location = new System.Drawing.Point(107, 77);
             this.linkLabel1.MinimumSize = new System.Drawing.Size(100, 0);
             this.linkLabel1.Name = "linkLabel1";
             this.linkLabel1.Size = new System.Drawing.Size(100, 13);
@@ -110,7 +110,7 @@
             this.checkTime.AutoSize = true;
             this.checkTime.Checked = true;
             this.checkTime.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkTime.Location = new System.Drawing.Point(100, 393);
+            this.checkTime.Location = new System.Drawing.Point(100, 378);
             this.checkTime.Name = "checkTime";
             this.checkTime.Size = new System.Drawing.Size(117, 17);
             this.checkTime.TabIndex = 14;
@@ -121,7 +121,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(107, 275);
+            this.label2.Location = new System.Drawing.Point(107, 260);
             this.label2.MinimumSize = new System.Drawing.Size(100, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(100, 13);
@@ -131,7 +131,7 @@
             // 
             // stateBox
             // 
-            this.stateBox.Location = new System.Drawing.Point(107, 291);
+            this.stateBox.Location = new System.Drawing.Point(107, 276);
             this.stateBox.MaxLength = 128;
             this.stateBox.Name = "stateBox";
             this.stateBox.Size = new System.Drawing.Size(100, 20);
@@ -141,7 +141,7 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(107, 226);
+            this.label3.Location = new System.Drawing.Point(107, 211);
             this.label3.MinimumSize = new System.Drawing.Size(100, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(100, 13);
@@ -151,7 +151,7 @@
             // 
             // smallKeyBox
             // 
-            this.smallKeyBox.Location = new System.Drawing.Point(107, 242);
+            this.smallKeyBox.Location = new System.Drawing.Point(107, 227);
             this.smallKeyBox.MaxLength = 32;
             this.smallKeyBox.Name = "smallKeyBox";
             this.smallKeyBox.Size = new System.Drawing.Size(100, 20);
@@ -161,7 +161,7 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(107, 142);
+            this.label4.Location = new System.Drawing.Point(107, 127);
             this.label4.MinimumSize = new System.Drawing.Size(100, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(100, 13);
@@ -171,7 +171,7 @@
             // 
             // bigKeyBox
             // 
-            this.bigKeyBox.Location = new System.Drawing.Point(107, 158);
+            this.bigKeyBox.Location = new System.Drawing.Point(107, 143);
             this.bigKeyBox.MaxLength = 32;
             this.bigKeyBox.Name = "bigKeyBox";
             this.bigKeyBox.Size = new System.Drawing.Size(100, 20);
@@ -181,7 +181,7 @@
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(107, 186);
+            this.label5.Location = new System.Drawing.Point(107, 171);
             this.label5.MinimumSize = new System.Drawing.Size(100, 0);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(100, 13);
@@ -191,7 +191,7 @@
             // 
             // bigTextBox
             // 
-            this.bigTextBox.Location = new System.Drawing.Point(107, 202);
+            this.bigTextBox.Location = new System.Drawing.Point(107, 187);
             this.bigTextBox.MaxLength = 128;
             this.bigTextBox.Name = "bigTextBox";
             this.bigTextBox.Size = new System.Drawing.Size(100, 20);
@@ -202,7 +202,7 @@
             // 
             this.statusLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.statusLabel.ForeColor = System.Drawing.Color.Red;
-            this.statusLabel.Location = new System.Drawing.Point(12, 314);
+            this.statusLabel.Location = new System.Drawing.Point(12, 299);
             this.statusLabel.Name = "statusLabel";
             this.statusLabel.Size = new System.Drawing.Size(290, 41);
             this.statusLabel.TabIndex = 12;
@@ -241,7 +241,7 @@
             // checkTray
             // 
             this.checkTray.AutoSize = true;
-            this.checkTray.Location = new System.Drawing.Point(100, 416);
+            this.checkTray.Location = new System.Drawing.Point(100, 401);
             this.checkTray.Name = "checkTray";
             this.checkTray.Size = new System.Drawing.Size(102, 17);
             this.checkTray.TabIndex = 15;
@@ -251,7 +251,7 @@
             // macButton
             // 
             this.macButton.Enabled = false;
-            this.macButton.Location = new System.Drawing.Point(213, 60);
+            this.macButton.Location = new System.Drawing.Point(213, 45);
             this.macButton.MinimumSize = new System.Drawing.Size(0, 22);
             this.macButton.Name = "macButton";
             this.macButton.Size = new System.Drawing.Size(62, 22);
@@ -266,13 +266,13 @@
             this.checkMainMenu.AutoSize = true;
             this.checkMainMenu.Checked = true;
             this.checkMainMenu.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkMainMenu.Location = new System.Drawing.Point(100, 439);
+            this.checkMainMenu.Location = new System.Drawing.Point(100, 424);
             this.checkMainMenu.Name = "checkMainMenu";
             this.checkMainMenu.Size = new System.Drawing.Size(170, 17);
             this.checkMainMenu.TabIndex = 18;
             this.checkMainMenu.Text = "Display Main Menu as a status";
             this.checkMainMenu.UseVisualStyleBackColor = true;
-            this.checkMainMenu.CheckedChanged += new System.EventHandler(this.checkMainMenu_CheckedChanged);
+            this.checkMainMenu.CheckedChanged += new System.EventHandler(this.CheckMainMenu_CheckedChanged);
             // 
             // MainForm
             // 

--- a/Client/SwitchPresence-Rewritten-GUI/MainForm.cs
+++ b/Client/SwitchPresence-Rewritten-GUI/MainForm.cs
@@ -349,6 +349,6 @@ namespace SwitchPresence_Rewritten_GUI
 
         private void LinkLabel1_LinkClicked_1(object sender, LinkLabelLinkClickedEventArgs e) => Process.Start($"https://discordapp.com/developers/applications/{clientBox.Text}");
 
-        private void checkMainMenu_CheckedChanged(object sender, EventArgs e) => ManualUpdate = true;
+        private void CheckMainMenu_CheckedChanged(object sender, EventArgs e) => ManualUpdate = true;
     }
 }

--- a/Client/SwitchPresence-Rewritten-GUI/MainForm.cs
+++ b/Client/SwitchPresence-Rewritten-GUI/MainForm.cs
@@ -207,10 +207,19 @@ namespace SwitchPresence_Rewritten_GUI
                         {
                             time = Timestamps.Now;
                         }
-                        if ((rpc != null && rpc.CurrentPresence == null) || LastGame != title.Name || ManualUpdate)
+                        if ((LastGame != title.Name) || ManualUpdate)
                         {
-                            rpc.SetPresence(PresenceCommon.Utils.CreateDiscordPresence(title, time, bigKeyBox.Text, bigTextBox.Text, smallKeyBox.Text, stateBox.Text));
-
+                            if (rpc != null)
+                            {
+                                if (checkMainMenu.Checked == false && title.Name == "NULL")
+                                {
+                                    rpc.ClearPresence();
+                                }
+                                else
+                                {
+                                    rpc.SetPresence(PresenceCommon.Utils.CreateDiscordPresence(title, time, bigKeyBox.Text, bigTextBox.Text, smallKeyBox.Text, stateBox.Text));
+                                }
+                            }
                             ManualUpdate = false;
                             LastGame = title.Name;
                         }
@@ -244,6 +253,7 @@ namespace SwitchPresence_Rewritten_GUI
                 stateBox.Text = cfg.State;
                 clientBox.Text = cfg.Client;
                 checkTray.Checked = cfg.AllowTray;
+                checkMainMenu.Checked = cfg.DisplayMainMenu;
             }
         }
 
@@ -279,7 +289,8 @@ namespace SwitchPresence_Rewritten_GUI
                     State = stateBox.Text,
                     BigText = bigTextBox.Text,
                     DisplayTimer = checkTime.Checked,
-                    AllowTray = checkTray.Checked
+                    AllowTray = checkTray.Checked,
+                    DisplayMainMenu = checkMainMenu.Checked
                 };
                 File.WriteAllText("Config.json", JsonConvert.SerializeObject(cfg));
             }
@@ -337,5 +348,7 @@ namespace SwitchPresence_Rewritten_GUI
         private void TrayExitMenuItem_Click(object sender, EventArgs e) => Application.Exit();
 
         private void LinkLabel1_LinkClicked_1(object sender, LinkLabelLinkClickedEventArgs e) => Process.Start($"https://discordapp.com/developers/applications/{clientBox.Text}");
+
+        private void checkMainMenu_CheckedChanged(object sender, EventArgs e) => ManualUpdate = true;
     }
 }


### PR DESCRIPTION
This is the compromise from my PRs in the past. I wish there was an option to not display main menu status on rich presence, because i'm often idle and it bugs the frick out of me.